### PR TITLE
chore: add site analytics

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -1,0 +1,5 @@
+# Website analytics
+
+The GitHub Pages documentation site loads Cloudflare Web Analytics from `docs/analytics.js` only when `docs/analytics-config.js` contains a beacon token and the visitor is on `vinodspattar.in`.
+
+Set the public browser beacon token in `docs/analytics-config.js`; leave it blank to disable tracking. The loader records Cloudflare's standard page views only, adds no user identifiers or custom event data, and does not load during local development. After deployment, confirm page views in the Cloudflare Web Analytics dashboard.

--- a/docs/analytics-config.js
+++ b/docs/analytics-config.js
@@ -1,0 +1,5 @@
+window.SITE_ANALYTICS = Object.freeze({
+  provider: "cloudflare-web-analytics",
+  token: "",
+  productionHosts: ["vinodspattar.in"],
+});

--- a/docs/analytics.js
+++ b/docs/analytics.js
@@ -1,0 +1,12 @@
+(function () {
+  "use strict";
+
+  const config = window.SITE_ANALYTICS;
+  if (!config?.token || !config.productionHosts?.includes(window.location.hostname)) return;
+
+  const beacon = document.createElement("script");
+  beacon.src = "https://static.cloudflareinsights.com/beacon.min.js";
+  beacon.dataset.cfBeacon = JSON.stringify({ token: config.token });
+  beacon.defer = true;
+  document.head.appendChild(beacon);
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,9 @@
       content="Organize GitHub stars with LLM classification, semantic search, and automated lists."
     />
     <link rel="stylesheet" href="./styles.css" />
-  </head>
+    <script src="./analytics-config.js" defer></script>
+  <script src="./analytics.js" defer></script>
+</head>
   <body>
     <header class="hero">
       <nav class="nav container">


### PR DESCRIPTION
## What changed

- Added a configuration-gated Cloudflare Web Analytics integration. Shared static-site loader at the GitHub Pages publication root.
- It runs only for the deployed production host and records standard page views.
## Validation

- Static HTML coverage and JavaScript syntax checks passed; `git diff --check` passed.
## Deployment configuration

- Add the public Cloudflare Web Analytics beacon token to the committed `analytics-config.js` file for the published site; leave it blank to disable tracking.
## Privacy

- No PII, form contents, user identifiers, session replay, or custom event data is intentionally collected.